### PR TITLE
add ENABLE_PHI to gearbox deployment

### DIFF
--- a/gen3/bin/kube-setup-gearbox.sh
+++ b/gen3/bin/kube-setup-gearbox.sh
@@ -31,7 +31,7 @@ setup_database() {
       return 1
     fi
 
-    if g3k_config_lookup '.gearbox.enable_phi' 2> /dev/null; then
+    if g3k_config_lookup '.global.enable_phi' 2> /dev/null; then
       ENABLE_PHI=True
     else
       ENABLE_PHI=False

--- a/gen3/bin/kube-setup-gearbox.sh
+++ b/gen3/bin/kube-setup-gearbox.sh
@@ -31,6 +31,12 @@ setup_database() {
       return 1
     fi
 
+    if g3k_config_lookup '.gearbox.enable_phi' 2> /dev/null; then
+      ENABLE_PHI=True
+    else
+      ENABLE_PHI=False
+    fi
+
     # go ahead and rotate the password whenever we regen this file
     local password="$(gen3 random)"
     cat - > "$secretsFolder/gearbox.env" <<EOM
@@ -46,7 +52,7 @@ S3_AWS_ACCESS_KEY_ID=$(jq -r .gearbox.gearbox_bucket_aws_key_id < "$GEN3_SECRETS
 S3_AWS_SECRET_ACCESS_KEY=$(jq -r .gearbox.gearbox_bucket_aws_access_key < "$GEN3_SECRETS_HOME/creds.json")
 
 ADMIN_LOGINS=gateway:$password
-ENABLE_PHI=False
+ENABLE_PHI=$ENABLE_PHI
 EOM
     # make it easy for nginx to get the Authorization header ...
     echo -n "gateway:$password" | base64 > "$secretsFolder/base64Authz.txt"

--- a/gen3/bin/kube-setup-gearbox.sh
+++ b/gen3/bin/kube-setup-gearbox.sh
@@ -46,6 +46,7 @@ S3_AWS_ACCESS_KEY_ID=$(jq -r .gearbox.gearbox_bucket_aws_key_id < "$GEN3_SECRETS
 S3_AWS_SECRET_ACCESS_KEY=$(jq -r .gearbox.gearbox_bucket_aws_access_key < "$GEN3_SECRETS_HOME/creds.json")
 
 ADMIN_LOGINS=gateway:$password
+ENABLE_PHI=False
 EOM
     # make it easy for nginx to get the Authorization header ...
     echo -n "gateway:$password" | base64 > "$secretsFolder/base64Authz.txt"

--- a/gen3/lib/bootstrap/templates/cdis-manifest/manifest.json
+++ b/gen3/lib/bootstrap/templates/cdis-manifest/manifest.json
@@ -44,7 +44,8 @@
     "portal_app": "dev",
     "sync_from_dbgap": "False",
     "useryaml_s3path": "",
-    "netpolicy": "on"
+    "netpolicy": "on",
+    "enable_phi": false
   },
   "canary": {
     "default": 0


### PR DESCRIPTION
Enable_PHI will be added to gearbox.env which is added as a volume mount, so an admin will have to manually change it in this file.