### PR TITLE
Remove custom command from portal deployment YAMLs

### DIFF
--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -92,9 +92,6 @@ spec:
         ports:
         - containerPort: 80
         - containerPort: 443
-        command: 
-          - /bin/bash
-          - ./dockerStart.sh
         env:
           - name: HOSTNAME
             value: revproxy-service

--- a/kube/services/portal/portal-root-deploy.yaml
+++ b/kube/services/portal/portal-root-deploy.yaml
@@ -92,9 +92,6 @@ spec:
         ports:
         - containerPort: 80
         - containerPort: 443
-        command:
-          - /bin/bash
-          - ./dockerStart.sh
         env:
           - name: HOSTNAME
             value: revproxy-service


### PR DESCRIPTION
Eliminated the explicit /bin/bash ./dockerStart.sh command from both portal-deploy.yaml and portal-root-deploy.yaml. The containers will now use their default entrypoint, simplifying deployment configuration.