### PR TITLE
add ARN role assume permission for GEARBOX dev to prod data deployment

### DIFF
--- a/gen3/bin/kube-setup-gearbox.sh
+++ b/gen3/bin/kube-setup-gearbox.sh
@@ -55,6 +55,23 @@ ADMIN_LOGINS=gateway:$password
 ENABLE_PHI=$ENABLE_PHI
 BYPASS_IMPORTANT_QUESTIONS=True
 EOM
+    if g3k_config_lookup '.gearbox.staging_data_mode' >/dev/null 2>&1; then
+      if s3_prod_bucket_name=$(g3k_config_lookup '.gearbox.s3_prod_bucket_name' 2>/dev/null) \
+        && prod_promotion_role_arn=$(g3k_config_lookup '.gearbox.prod_promotion_role_arn' 2>/dev/null); then
+
+        # Only append if both values are non-empty
+        if [[ -n "$s3_prod_bucket_name" && -n "$prod_promotion_role_arn" ]]; then
+          echo "S3_PROD_BUCKET_NAME=$s3_prod_bucket_name" >> "$secretsFolder/gearbox.env"
+          echo "PROD_PROMOTION_ROLE_ARN=$prod_promotion_role_arn" >> "$secretsFolder/gearbox.env"
+        else
+          gen3_log_warn "staging_data_mode enabled but prod bucket/role values are empty"
+        fi
+
+      else
+        gen3_log_warn "staging_data_mode enabled but prod bucket/role keys missing in manifest"
+      fi
+    fi
+
     # make it easy for nginx to get the Authorization header ...
     echo -n "gateway:$password" | base64 > "$secretsFolder/base64Authz.txt"
   fi

--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -32,11 +32,14 @@ module "cdis_vpc" {
   vpc_flow_traffic               = "${var.vpc_flow_traffic}"
 
   #private_kube_route             = "${aws_route_table.private_kube.id}"
-  branch                         = "${var.branch}"
-  fence-bot_bucket_access_arns   = "${var.fence-bot_bucket_access_arns}"
+  branch                          = "${var.branch}"
+  fence-bot_bucket_access_arns    = "${var.fence-bot_bucket_access_arns}"
   amanuensis-bot_bucket_access_arns   = "${var.amanuensis-bot_bucket_access_arns}"
-  gearbox-bot_bucket_access_arns   = "${var.gearbox-bot_bucket_access_arns}"
-  gearbox_allowed_origins        = "${split(",",var.hostname)}"
+  gearbox-bot_bucket_access_arns      = "${var.gearbox-bot_bucket_access_arns}"
+  gearbox_allowed_origins             = "${split(",",var.hostname)}"
+  prod_promotion_role_arn             = "${var.prod_promotion_role_arn}"
+  staging_account_id                  = "${var.staging_account_id}"
+
   deploy_ha_squid                = "${var.deploy_ha_squid}"
   deploy_single_proxy            = "${var.deploy_single_proxy}"
 

--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -39,6 +39,8 @@ module "cdis_vpc" {
   gearbox_allowed_origins             = "${split(",",var.hostname)}"
   prod_promotion_role_arn             = "${var.prod_promotion_role_arn}"
   staging_account_id                  = "${var.staging_account_id}"
+  is_gearbox_staging                  = "${var.is_gearbox_staging}"
+  is_gearbox_prod                     = "${var.is_gearbox_prod}"
 
   deploy_ha_squid                = "${var.deploy_ha_squid}"
   deploy_single_proxy            = "${var.deploy_single_proxy}"

--- a/tf_files/aws/commons/outputs.tf
+++ b/tf_files/aws/commons/outputs.tf
@@ -71,6 +71,10 @@ output "gearbox-bot_user_id" {
   value = "${module.cdis_vpc.gearbox-bot_id}"
 }
 
+output "gearbox-bot-prod_promotion_role_arn" {
+  value = "${module.cdis_vpc.gearbox-bot-prod_promotion_role_arn}"
+}
+
 output "gearbox-match-conditions-bucket_name" {
   value = "${module.cdis_vpc.gearbox-match-conditions-bucket_name}"
 }

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -538,14 +538,12 @@ variable "gearbox_allowed_origins" {
 }
 
 variable "prod_promotion_role_arn" {
-  type        = string
-  default     = null
+  default     = ""
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
 
 variable "staging_account_id" {
-  type        = string
-  default     = null
+  default     = ""
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
 

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -536,3 +536,16 @@ variable "gearbox_allowed_origins" {
   type = "list"
   default = []
 }
+
+variable "prod_promotion_role_arn" {
+  type        = string
+  default     = null
+  description = "Role ARN in PROD that staging can assume. Null in prod."
+}
+
+variable "staging_account_id" {
+  type        = string
+  default     = null
+  description = "Role ARN in PROD that staging can assume. Null in prod."
+}
+

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -547,3 +547,10 @@ variable "staging_account_id" {
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
 
+variable "is_gearbox_staging" {
+  default = false
+}
+
+variable "is_gearbox_prod" {
+  default = false
+}

--- a/tf_files/aws/modules/data-bucket-with-versioning/s3.tf
+++ b/tf_files/aws/modules/data-bucket-with-versioning/s3.tf
@@ -2,10 +2,25 @@
 #------------- LOGGING
 resource "aws_s3_bucket" "log_bucket" {
   bucket = "${var.vpc_name}-data-bucket-with-versioning-log"
+
+  # ACL to allow S3 log delivery
+  acl = "log-delivery-write"
+
+  # Server-side encryption to match current state
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
   tags = {
     Purpose = "s3 bucket log bucket"
   }
 }
+
+
 
 resource "aws_s3_bucket" "data_bucket" {
   bucket = "${var.vpc_name}-data-bucket-with-versioning"

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -109,7 +109,7 @@ EOF
 
 
 resource "aws_iam_policy" "allow_assume_prod_role" {
-  count = var.is_gearbox_staging ? 1 : 0
+  count = "${var.is_gearbox_staging ? 1 : 0}"
 
   name = "${var.vpc_name}-allow-assume-prod-promotion-role"
 
@@ -128,7 +128,7 @@ POLICY
 }
 
 resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
-  count = var.is_gearbox_staging ? 1 : 0
+  count = "${var.is_gearbox_staging ? 1 : 0}"
 
   user       = "${aws_iam_user.gearbox-bot.name}"
   policy_arn = "${aws_iam_policy.allow_assume_prod_role[0].arn}"
@@ -203,7 +203,7 @@ resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
 */
 
 resource "aws_iam_role" "staging_promotion_role" {
-  count = var.is_gearbox_prod ? 1 : 0
+  count = "${var.is_gearbox_prod ? 1 : 0}"
 
   name = "${var.vpc_name}-staging-promote-to-prod-role"
 
@@ -224,7 +224,7 @@ POLICY
 }
 
 resource "aws_iam_policy" "staging_promotion_policy" {
-  count = var.is_gearbox_prod ? 1 : 0
+  count = "${var.is_gearbox_prod ? 1 : 0}"
 
   name = "${var.vpc_name}-staging-promote-to-prod-policy"
 
@@ -253,7 +253,7 @@ POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
-  count = var.is_gearbox_prod ? 1 : 0
+  count = "${var.is_gearbox_prod ? 1 : 0}"
 
   role       = "${aws_iam_role.staging_promotion_role[0].name}"
   policy_arn = "${aws_iam_policy.staging_promotion_policy[0].arn}"

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -82,7 +82,7 @@ EOF
 ## FOR STAGInG ACCOUNT TO PUSH TO PROD
 # START
 resource "aws_iam_policy" "allow_assume_prod_role" {
-  count = var.prod_promotion_role_arn == null ? 0 : 1
+  count = var.prod_promotion_role_arn == "" ? 0 : 1
 
   name = "${var.vpc_name}-allow-assume-prod-promotion-role"
 
@@ -99,7 +99,7 @@ resource "aws_iam_policy" "allow_assume_prod_role" {
 }
 
 resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
-  count = var.prod_promotion_role_arn == null ? 0 : 1
+  count = var.prod_promotion_role_arn == "" ? 0 : 1
 
   user       = aws_iam_user.gearbox-bot.name
   policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
@@ -110,6 +110,8 @@ resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
 ### FOR PROD account to allow staging to get access to the role
 # START
 resource "aws_iam_role" "staging_promotion_role" {
+  count = var.staging_account_id == "" ? 0 : 1
+
   name = "${var.vpc_name}-staging-promote-to-prod-role"
 
   assume_role_policy = jsonencode({
@@ -127,6 +129,8 @@ resource "aws_iam_role" "staging_promotion_role" {
 }
 
 resource "aws_iam_policy" "staging_promotion_policy" {
+  count = var.staging_account_id == "" ? 0 : 1
+
   name = "${var.vpc_name}-staging-promote-to-prod-policy"
 
   policy = jsonencode({
@@ -154,8 +158,10 @@ resource "aws_iam_policy" "staging_promotion_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
-  role       = aws_iam_role.staging_promotion_role.name
-  policy_arn = aws_iam_policy.staging_promotion_policy.arn
+  count = var.staging_account_id == "" ? 0 : 1
+
+  role       = aws_iam_role.staging_promotion_role[0].name
+  policy_arn = aws_iam_policy.staging_promotion_policy[0].arn
 }
 # END
 

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -127,7 +127,6 @@ resource "aws_iam_user_policy" "gearbox_bot_assume_prod" {
 POLICY
 }
 
-
 # END
 
 
@@ -196,6 +195,8 @@ POLICY
 #}
 
 
+
+
 resource "aws_iam_role" "staging_promotion_role" {
   count = "${var.is_gearbox_prod ? 1 : 0}"
 
@@ -249,8 +250,8 @@ POLICY
 resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
   count = "${var.is_gearbox_prod ? 1 : 0}"
 
-  role       = "${aws_iam_role.staging_promotion_role[0].name}"
-  policy_arn = "${aws_iam_policy.staging_promotion_policy[0].arn}"
+  role       = "${element(aws_iam_role.staging_promotion_role.*.name, 0)}"
+  policy_arn = "${element(aws_iam_policy.staging_promotion_policy.*.arn, 0)}"
 }
 
 # END

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -76,3 +76,32 @@ resource "aws_iam_user_policy" "gearbox-bot_extra_policy" {
 }
 EOF
 }
+
+
+resource "aws_iam_policy" "allow_assume_prod_role" {
+  count = var.prod_promotion_role_arn == null ? 0 : 1
+
+  name = "${var.vpc_name}-allow-assume-prod-promotion-role"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect   = "Allow",
+        Action   = "sts:AssumeRole",
+        Resource = var.prod_promotion_role_arn
+      }
+    ]
+  })
+}
+
+resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
+  count = var.prod_promotion_role_arn == null ? 0 : 1
+
+  user       = aws_iam_user.gearbox-bot.name
+  policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
+}
+
+
+
+

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -127,11 +127,15 @@ resource "aws_iam_policy" "allow_assume_prod_role" {
 POLICY
 }
 
+locals {
+  assume_prod_policy_arn = "${var.is_gearbox_staging ? aws_iam_policy.allow_assume_prod_role[0].arn : ""}"
+}
+
 resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
   count = "${var.is_gearbox_staging ? 1 : 0}"
 
   user       = "${aws_iam_user.gearbox-bot.name}"
-  policy_arn = "${aws_iam_policy.allow_assume_prod_role[0].arn}"
+  policy_arn = "${local.assume_prod_policy_arn}"
 }
 
 # END

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -81,51 +81,146 @@ EOF
 
 ## FOR STAGING ACCOUNT TO PUSH TO PROD
 # START
+
+### later terraform version
+#resource "aws_iam_policy" "allow_assume_prod_role" {
+#  count = var.is_gearbox_staging ? 1 : 0
+#
+#  name = "${var.vpc_name}-allow-assume-prod-promotion-role"
+#
+#  policy = jsonencode({
+#    Version = "2012-10-17",
+#    Statement = [
+#      {
+#        Effect   = "Allow",
+#        Action   = "sts:AssumeRole",
+#        Resource = var.prod_promotion_role_arn
+#      }
+#    ]
+#  })
+#}
+#
+#resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
+#  count = var.is_gearbox_staging ? 1 : 0
+#
+#  user       = aws_iam_user.gearbox-bot.name
+#  policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
+#}
+
+
 resource "aws_iam_policy" "allow_assume_prod_role" {
   count = var.is_gearbox_staging ? 1 : 0
 
   name = "${var.vpc_name}-allow-assume-prod-promotion-role"
 
-  policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [
-      {
-        Effect   = "Allow",
-        Action   = "sts:AssumeRole",
-        Resource = var.prod_promotion_role_arn
-      }
-    ]
-  })
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "${var.prod_promotion_role_arn}"
+    }
+  ]
+}
+POLICY
 }
 
 resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
   count = var.is_gearbox_staging ? 1 : 0
 
-  user       = aws_iam_user.gearbox-bot.name
-  policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
+  user       = "${aws_iam_user.gearbox-bot.name}"
+  policy_arn = "${aws_iam_policy.allow_assume_prod_role[0].arn}"
 }
+
 # END
+
+
+
+
+
 
 
 ### FOR PROD account to allow staging to get access to the role
 # START
+
+### later terraform version
+#resource "aws_iam_role" "staging_promotion_role" {
+#  count = var.is_gearbox_prod ? 1 : 0
+#
+#  name = "${var.vpc_name}-staging-promote-to-prod-role"
+#
+#  assume_role_policy = jsonencode({
+#    Version = "2012-10-17"
+#    Statement = [
+#      {
+#        Effect = "Allow"
+#        Principal = {
+#          AWS = "arn:aws:iam::${var.staging_account_id}:root"
+#        }
+#        Action = "sts:AssumeRole"
+#      }
+#    ]
+#  })
+#}
+#
+#resource "aws_iam_policy" "staging_promotion_policy" {
+#  count = var.is_gearbox_prod ? 1 : 0
+#
+#  name = "${var.vpc_name}-staging-promote-to-prod-policy"
+#
+#  policy = jsonencode({
+#    Version = "2012-10-17"
+#    Statement = [
+#      {
+#        Effect = "Allow"
+#        Action = [
+#          "s3:ListBucket"
+#        ]
+#        Resource = "arn:aws:s3:::${var.bucket_name}"
+#      },
+#      {
+#        Effect = "Allow"
+#        Action = [
+#          "s3:GetObject",
+#          "s3:GetObjectVersion",
+#          "s3:PutObject",
+#          "s3:DeleteObject"
+#        ]
+#        Resource = "arn:aws:s3:::${var.bucket_name}/*"
+#      }
+#    ]
+#  })
+#}
+#
+#resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
+#  count = var.is_gearbox_prod ? 1 : 0
+#
+#  role       = aws_iam_role.staging_promotion_role[0].name
+#  policy_arn = aws_iam_policy.staging_promotion_policy[0].arn
+#}
+*/
+
 resource "aws_iam_role" "staging_promotion_role" {
   count = var.is_gearbox_prod ? 1 : 0
 
   name = "${var.vpc_name}-staging-promote-to-prod-role"
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          AWS = "arn:aws:iam::${var.staging_account_id}:root"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${var.staging_account_id}:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
 }
 
 resource "aws_iam_policy" "staging_promotion_policy" {
@@ -133,36 +228,37 @@ resource "aws_iam_policy" "staging_promotion_policy" {
 
   name = "${var.vpc_name}-staging-promote-to-prod-policy"
 
-  policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:ListBucket"
-        ]
-        Resource = "arn:aws:s3:::${var.bucket_name}"
-      },
-      {
-        Effect = "Allow"
-        Action = [
-          "s3:GetObject",
-          "s3:GetObjectVersion",
-          "s3:PutObject",
-          "s3:DeleteObject"
-        ]
-        Resource = "arn:aws:s3:::${var.bucket_name}/*"
-      }
-    ]
-  })
+  policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": "arn:aws:s3:::${var.bucket_name}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::${var.bucket_name}/*"
+    }
+  ]
+}
+POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
   count = var.is_gearbox_prod ? 1 : 0
 
-  role       = aws_iam_role.staging_promotion_role[0].name
-  policy_arn = aws_iam_policy.staging_promotion_policy[0].arn
+  role       = "${aws_iam_role.staging_promotion_role[0].name}"
+  policy_arn = "${aws_iam_policy.staging_promotion_policy[0].arn}"
 }
+
 # END
 
 

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -79,10 +79,10 @@ EOF
 
 
 
-## FOR STAGInG ACCOUNT TO PUSH TO PROD
+## FOR STAGING ACCOUNT TO PUSH TO PROD
 # START
 resource "aws_iam_policy" "allow_assume_prod_role" {
-  count = length(var.prod_promotion_role_arn) > 0 ? 1 : 0
+  count = var.is_gearbox_staging ? 1 : 0
 
   name = "${var.vpc_name}-allow-assume-prod-promotion-role"
 
@@ -99,7 +99,7 @@ resource "aws_iam_policy" "allow_assume_prod_role" {
 }
 
 resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
-  count = length(var.prod_promotion_role_arn) > 0 ? 1 : 0
+  count = var.is_gearbox_staging ? 1 : 0
 
   user       = aws_iam_user.gearbox-bot.name
   policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
@@ -110,7 +110,7 @@ resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
 ### FOR PROD account to allow staging to get access to the role
 # START
 resource "aws_iam_role" "staging_promotion_role" {
-  count = length(var.staging_account_id) > 0 ? 1 : 0
+  count = var.is_gearbox_prod ? 1 : 0
 
   name = "${var.vpc_name}-staging-promote-to-prod-role"
 
@@ -129,7 +129,7 @@ resource "aws_iam_role" "staging_promotion_role" {
 }
 
 resource "aws_iam_policy" "staging_promotion_policy" {
-  count = length(var.staging_account_id) > 0 ? 1 : 0
+  count = var.is_gearbox_prod ? 1 : 0
 
   name = "${var.vpc_name}-staging-promote-to-prod-policy"
 
@@ -158,7 +158,7 @@ resource "aws_iam_policy" "staging_promotion_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
-  count = length(var.staging_account_id) > 0 ? 1 : 0
+  count = var.is_gearbox_prod ? 1 : 0
 
   role       = aws_iam_role.staging_promotion_role[0].name
   policy_arn = aws_iam_policy.staging_promotion_policy[0].arn

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -107,11 +107,11 @@ EOF
 #  policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
 #}
 
-
-resource "aws_iam_policy" "allow_assume_prod_role" {
+resource "aws_iam_user_policy" "gearbox_bot_assume_prod" {
   count = "${var.is_gearbox_staging ? 1 : 0}"
 
-  name = "${var.vpc_name}-allow-assume-prod-promotion-role"
+  name = "${var.vpc_name}-assume-prod-role"
+  user = "${aws_iam_user.gearbox-bot.name}"
 
   policy = <<POLICY
 {
@@ -127,16 +127,6 @@ resource "aws_iam_policy" "allow_assume_prod_role" {
 POLICY
 }
 
-locals {
-  assume_prod_policy_arn = "${var.is_gearbox_staging ? aws_iam_policy.allow_assume_prod_role[0].arn : ""}"
-}
-
-resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
-  count = "${var.is_gearbox_staging ? 1 : 0}"
-
-  user       = "${aws_iam_user.gearbox-bot.name}"
-  policy_arn = "${local.assume_prod_policy_arn}"
-}
 
 # END
 

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -200,7 +200,7 @@ resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
 #  role       = aws_iam_role.staging_promotion_role[0].name
 #  policy_arn = aws_iam_policy.staging_promotion_policy[0].arn
 #}
-*/
+
 
 resource "aws_iam_role" "staging_promotion_role" {
   count = "${var.is_gearbox_prod ? 1 : 0}"

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -82,7 +82,7 @@ EOF
 ## FOR STAGInG ACCOUNT TO PUSH TO PROD
 # START
 resource "aws_iam_policy" "allow_assume_prod_role" {
-  count = var.prod_promotion_role_arn == "" ? 0 : 1
+  count = length(var.prod_promotion_role_arn) > 0 ? 1 : 0
 
   name = "${var.vpc_name}-allow-assume-prod-promotion-role"
 
@@ -99,7 +99,7 @@ resource "aws_iam_policy" "allow_assume_prod_role" {
 }
 
 resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
-  count = var.prod_promotion_role_arn == "" ? 0 : 1
+  count = length(var.prod_promotion_role_arn) > 0 ? 1 : 0
 
   user       = aws_iam_user.gearbox-bot.name
   policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
@@ -110,7 +110,7 @@ resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
 ### FOR PROD account to allow staging to get access to the role
 # START
 resource "aws_iam_role" "staging_promotion_role" {
-  count = var.staging_account_id == "" ? 0 : 1
+  count = length(var.staging_account_id) > 0 ? 1 : 0
 
   name = "${var.vpc_name}-staging-promote-to-prod-role"
 
@@ -129,7 +129,7 @@ resource "aws_iam_role" "staging_promotion_role" {
 }
 
 resource "aws_iam_policy" "staging_promotion_policy" {
-  count = var.staging_account_id == "" ? 0 : 1
+  count = length(var.staging_account_id) > 0 ? 1 : 0
 
   name = "${var.vpc_name}-staging-promote-to-prod-policy"
 
@@ -158,7 +158,7 @@ resource "aws_iam_policy" "staging_promotion_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
-  count = var.staging_account_id == "" ? 0 : 1
+  count = length(var.staging_account_id) > 0 ? 1 : 0
 
   role       = aws_iam_role.staging_promotion_role[0].name
   policy_arn = aws_iam_policy.staging_promotion_policy[0].arn

--- a/tf_files/aws/modules/gearbox-bot-user/iam.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/iam.tf
@@ -78,6 +78,9 @@ EOF
 }
 
 
+
+## FOR STAGInG ACCOUNT TO PUSH TO PROD
+# START
 resource "aws_iam_policy" "allow_assume_prod_role" {
   count = var.prod_promotion_role_arn == null ? 0 : 1
 
@@ -101,7 +104,59 @@ resource "aws_iam_user_policy_attachment" "gearbox_bot_assume_prod" {
   user       = aws_iam_user.gearbox-bot.name
   policy_arn = aws_iam_policy.allow_assume_prod_role[0].arn
 }
+# END
 
 
+### FOR PROD account to allow staging to get access to the role
+# START
+resource "aws_iam_role" "staging_promotion_role" {
+  name = "${var.vpc_name}-staging-promote-to-prod-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = "arn:aws:iam::${var.staging_account_id}:root"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "staging_promotion_policy" {
+  name = "${var.vpc_name}-staging-promote-to-prod-policy"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket"
+        ]
+        Resource = "arn:aws:s3:::${var.bucket_name}"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:PutObject",
+          "s3:DeleteObject"
+        ]
+        Resource = "arn:aws:s3:::${var.bucket_name}/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_promote_policy" {
+  role       = aws_iam_role.staging_promotion_role.name
+  policy_arn = aws_iam_policy.staging_promotion_policy.arn
+}
+# END
 
 

--- a/tf_files/aws/modules/gearbox-bot-user/output.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/output.tf
@@ -7,3 +7,6 @@ output "gearbox-bot_id" {
   value = "${aws_iam_access_key.gearbox-bot_user_key.id}"
 }
 
+output "prod_promotion_role_arn" {
+  value = aws_iam_role.staging_promotion_role.arn
+}

--- a/tf_files/aws/modules/gearbox-bot-user/output.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/output.tf
@@ -8,5 +8,6 @@ output "gearbox-bot_id" {
 }
 
 output "prod_promotion_role_arn" {
-  value = aws_iam_role.staging_promotion_role.arn
+  value = length(aws_iam_role.staging_promotion_role) > 0 ? aws_iam_role.staging_promotion_role[0].arn : ""
+  description = "ARN of the staging promotion role, empty if not created"
 }

--- a/tf_files/aws/modules/gearbox-bot-user/output.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/output.tf
@@ -8,6 +8,6 @@ output "gearbox-bot_id" {
 }
 
 output "prod_promotion_role_arn" {
-  value = length(aws_iam_role.staging_promotion_role) > 0 ? aws_iam_role.staging_promotion_role[0].arn : ""
+  value = var.is_gearbox_prod ? aws_iam_role.staging_promotion_role[0].arn : ""
   description = "ARN of the staging promotion role, empty if not created"
 }

--- a/tf_files/aws/modules/gearbox-bot-user/output.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/output.tf
@@ -7,7 +7,17 @@ output "gearbox-bot_id" {
   value = "${aws_iam_access_key.gearbox-bot_user_key.id}"
 }
 
+# output "prod_promotion_role_arn" {
+#  value = var.is_gearbox_prod ? aws_iam_role.staging_promotion_role[0].arn : ""
+#  description = "ARN of the staging promotion role, empty if not created"
+#}
+
+#output "prod_promotion_role_arn" {
+#  value = "${var.is_gearbox_prod ? element(concat(aws_iam_role.staging_promotion_role.*.arn, list("")), 0) : ""}"
+#  description = "ARN of the staging promotion role, empty if not created"
+#}
+
 output "prod_promotion_role_arn" {
-  value = var.is_gearbox_prod ? aws_iam_role.staging_promotion_role[0].arn : ""
+  value = "${var.is_gearbox_prod ? join("", aws_iam_role.staging_promotion_role.*.arn) : ""}"
   description = "ARN of the staging promotion role, empty if not created"
 }

--- a/tf_files/aws/modules/gearbox-bot-user/variables.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/variables.tf
@@ -10,3 +10,10 @@ variable "bucket_access_arns" {
   type        = "list"
   default     = []
 }
+
+
+variable "prod_promotion_role_arn" {
+  type        = string
+  default     = null
+  description = "Role ARN in PROD that staging can assume. Null in prod."
+}

--- a/tf_files/aws/modules/gearbox-bot-user/variables.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/variables.tf
@@ -17,3 +17,10 @@ variable "prod_promotion_role_arn" {
   default     = null
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
+
+variable "staging_account_id" {
+  type        = string
+  default     = null
+  description = "Role ARN in PROD that staging can assume. Null in prod."
+}
+

--- a/tf_files/aws/modules/gearbox-bot-user/variables.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/variables.tf
@@ -22,3 +22,10 @@ variable "staging_account_id" {
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
 
+variable "is_gearbox_staging" {
+  default = false
+}
+
+variable "is_gearbox_prod" {
+  default = false
+}

--- a/tf_files/aws/modules/gearbox-bot-user/variables.tf
+++ b/tf_files/aws/modules/gearbox-bot-user/variables.tf
@@ -13,14 +13,12 @@ variable "bucket_access_arns" {
 
 
 variable "prod_promotion_role_arn" {
-  type        = string
-  default     = null
+  default     = ""
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
 
 variable "staging_account_id" {
-  type        = string
-  default     = null
+  default     = ""
   description = "Role ARN in PROD that staging can assume. Null in prod."
 }
 

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -91,6 +91,7 @@ module "gearbox-bot-user" {
   bucket_name          = "${module.gearbox-match-conditions-bucket.data-bucket-with-versioning_name}"
   bucket_access_arns   = "${var.gearbox-bot_bucket_access_arns}"
   prod_promotion_role_arn = "${var.prod_promotion_role_arn}"
+  staging_account_id    = "${var.staging_account_id}"
 }
 
 resource "aws_vpc" "main" {

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -90,6 +90,7 @@ module "gearbox-bot-user" {
   vpc_name             = "${var.vpc_name}"
   bucket_name          = "${module.gearbox-match-conditions-bucket.data-bucket-with-versioning_name}"
   bucket_access_arns   = "${var.gearbox-bot_bucket_access_arns}"
+  prod_promotion_role_arn = "${var.prod_promotion_role_arn}"
 }
 
 resource "aws_vpc" "main" {

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -92,6 +92,8 @@ module "gearbox-bot-user" {
   bucket_access_arns   = "${var.gearbox-bot_bucket_access_arns}"
   prod_promotion_role_arn = "${var.prod_promotion_role_arn}"
   staging_account_id    = "${var.staging_account_id}"
+  is_gearbox_staging    = "${var.is_gearbox_staging}"
+  is_gearbox_prod       = "${var.is_gearbox_prod}"
 }
 
 resource "aws_vpc" "main" {

--- a/tf_files/aws/modules/vpc/outputs.tf
+++ b/tf_files/aws/modules/vpc/outputs.tf
@@ -97,6 +97,10 @@ output "gearbox-bot_secret" {
   value = "${module.gearbox-bot-user.gearbox-bot_secret}"
 }
 
+output "gearbox-bot-prod_promotion_role_arn" {
+  value = "${module.gearbox-bot-user.prod_promotion_role_arn}"
+}
+
 output "gearbox-match-conditions-bucket_name" {
   value = "${module.gearbox-match-conditions-bucket.data-bucket-with-versioning_name}"
 }

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -169,3 +169,8 @@ variable "prod_promotion_role_arn" {
   type    = string
   default = null
 }
+# Used for GEARBOX prod to allow dev/staging to get the role to move data to the prod S3
+variable "staging_account_id" {
+  type    = string
+  default = null
+}

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -172,3 +172,9 @@ variable "prod_promotion_role_arn" {
 variable "staging_account_id" {
   default = ""
 }
+variable "is_gearbox_staging" {
+  default = false
+}
+variable "is_gearbox_prod" {
+  default = false
+}

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -166,11 +166,9 @@ variable "fips" {
 
 # Used for GEARBOX dev/staging to move data to Prod S3 bucket
 variable "prod_promotion_role_arn" {
-  type    = string
-  default = null
+  default = ""
 }
 # Used for GEARBOX prod to allow dev/staging to get the role to move data to the prod S3
 variable "staging_account_id" {
-  type    = string
-  default = null
+  default = ""
 }

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -163,3 +163,9 @@ variable "slack_webhook" {
 variable "fips" {
   default = false
 }
+
+# Used for GEARBOX dev/staging to move data to Prod S3 bucket
+variable "prod_promotion_role_arn" {
+  type    = string
+  default = null
+}


### PR DESCRIPTION
This will need the manifest.json file to have this new block with the required information and of course a terraform apply to generate the new policy and attach it to the user.

<img width="468" height="110" alt="image" src="https://github.com/user-attachments/assets/c6baeb44-6947-4f9e-9121-6fea60c51643" />
